### PR TITLE
Develop/project add

### DIFF
--- a/lib/client/fetch_project_data.dart
+++ b/lib/client/fetch_project_data.dart
@@ -1,0 +1,13 @@
+import 'dart:math';
+
+import 'package:flutter_study_202209/model/project.dart';
+
+class FetchData {
+  static Project fetchProject() {
+    int id = Random().nextInt(100);
+    String name = "プロジェクト${id.toString()}";
+    String workTime = "${id.toString()}:${id.toString()}";
+    Project project = Project(id: id, name: name, workTime: workTime);
+    return project;
+  }
+}

--- a/lib/client/fetch_project_data.dart
+++ b/lib/client/fetch_project_data.dart
@@ -10,4 +10,16 @@ class FetchData {
     Project project = Project(id: id, name: name, workTime: workTime);
     return project;
   }
+
+  static List<String> fetchProjectNames() {
+    const List<String> projectNames = <String>[
+      'プロジェクト1',
+      'プロジェクト2',
+      'プロジェクト3',
+      'プロジェクト4',
+      'プロジェクト5',
+      'プロジェクト6',
+    ];
+    return projectNames;
+  }
 }

--- a/lib/components/drop_down_list.dart
+++ b/lib/components/drop_down_list.dart
@@ -1,15 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_study_202209/client/fetch_project_data.dart';
 
 const double _kItemExtent = 32.0;
-const List<String> _projectNames = <String>[
-  'プロジェクト1',
-  'プロジェクト2',
-  'プロジェクト3',
-  'プロジェクト4',
-  'プロジェクト5',
-  'プロジェクト6',
-];
 
 class DropDownList extends StatefulWidget {
   const DropDownList({Key? key}) : super(key: key);
@@ -19,6 +12,14 @@ class DropDownList extends StatefulWidget {
 }
 
 class _DropDownListState extends State<DropDownList> {
+  List<String> projectNames = [];
+
+  @override
+  void initState() {
+    projectNames = FetchData.fetchProjectNames();
+    super.initState();
+  }
+
   int _selectedProject = 0;
   void _showDialog(Widget child) {
     showCupertinoModalPopup<void>(
@@ -60,10 +61,10 @@ class _DropDownListState extends State<DropDownList> {
                 _selectedProject = selectedItem;
               });
             },
-            children: List<Widget>.generate(_projectNames.length, (int index) {
+            children: List<Widget>.generate(projectNames.length, (int index) {
               return Center(
                 child: Text(
-                  _projectNames[index],
+                  projectNames[index],
                 ),
               );
             }),
@@ -86,7 +87,7 @@ class _DropDownListState extends State<DropDownList> {
               Padding(
                 padding: const EdgeInsets.all(4.0),
                 child: Text(
-                  _projectNames[_selectedProject],
+                  projectNames[_selectedProject],
                   style: const TextStyle(
                     color: Colors.black,
                     fontSize: 16,

--- a/lib/components/project_card.dart
+++ b/lib/components/project_card.dart
@@ -6,8 +6,11 @@ import 'package:flutter_study_202209/model/project.dart';
 import 'package:flutter_study_202209/provider/project_addition_provider.dart';
 
 class ProjectCard extends ConsumerWidget {
-  const ProjectCard({Key? key, required this.project}) : super(key: key);
+  const ProjectCard(
+      {Key? key, required this.project, required this.projectNames})
+      : super(key: key);
   final Project project;
+  final List<String> projectNames;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -34,7 +37,7 @@ class ProjectCard extends ConsumerWidget {
               ),
             ],
           ),
-          DropDownList(),
+          const DropDownList(),
           Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: const [

--- a/lib/components/project_card.dart
+++ b/lib/components/project_card.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_study_202209/components/drop_down_list.dart';
 import 'package:flutter_study_202209/components/time_picker.dart';
+import 'package:flutter_study_202209/model/project.dart';
 import 'package:flutter_study_202209/provider/project_addition_provider.dart';
 
 class ProjectCard extends ConsumerWidget {
-  const ProjectCard({Key? key, required this.projectCount}) : super(key: key);
-  final int projectCount;
+  const ProjectCard({Key? key, required this.project}) : super(key: key);
+  final Project project;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final projectAdditionNotifier = ref.watch(projectAdditionProvider.notifier);
@@ -21,18 +23,18 @@ class ProjectCard extends ConsumerWidget {
         children: [
           Row(
             children: [
-              const Text("プロジェクト"),
-              Text((projectCount + 1).toString()),
+              Text(project.name),
+              Text((project.id).toString()),
               const Spacer(),
               IconButton(
                 icon: const Icon(Icons.cancel_outlined),
                 onPressed: () {
-                  projectAdditionNotifier.removeProject(projectCount);
+                  projectAdditionNotifier.removeProject(project.id);
                 },
               ),
             ],
           ),
-          const DropDownList(),
+          DropDownList(),
           Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: const [

--- a/lib/model/project.dart
+++ b/lib/model/project.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'project.freezed.dart';
+part 'project.g.dart';
+
+@freezed
+class Project with _$Project {
+  const Project._();
+
+  factory Project({
+    required int id,
+    required String name,
+    required String workTime,
+  }) = _Project;
+
+  factory Project.fromJson(Map<String, dynamic> json) =>
+      _$ProjectFromJson(json);
+}

--- a/lib/model/project.freezed.dart
+++ b/lib/model/project.freezed.dart
@@ -1,0 +1,182 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'project.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Project _$ProjectFromJson(Map<String, dynamic> json) {
+  return _Project.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Project {
+  int get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get workTime => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ProjectCopyWith<Project> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProjectCopyWith<$Res> {
+  factory $ProjectCopyWith(Project value, $Res Function(Project) then) =
+      _$ProjectCopyWithImpl<$Res>;
+  $Res call({int id, String name, String workTime});
+}
+
+/// @nodoc
+class _$ProjectCopyWithImpl<$Res> implements $ProjectCopyWith<$Res> {
+  _$ProjectCopyWithImpl(this._value, this._then);
+
+  final Project _value;
+  // ignore: unused_field
+  final $Res Function(Project) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? name = freezed,
+    Object? workTime = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      workTime: workTime == freezed
+          ? _value.workTime
+          : workTime // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_ProjectCopyWith<$Res> implements $ProjectCopyWith<$Res> {
+  factory _$$_ProjectCopyWith(
+          _$_Project value, $Res Function(_$_Project) then) =
+      __$$_ProjectCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, String name, String workTime});
+}
+
+/// @nodoc
+class __$$_ProjectCopyWithImpl<$Res> extends _$ProjectCopyWithImpl<$Res>
+    implements _$$_ProjectCopyWith<$Res> {
+  __$$_ProjectCopyWithImpl(_$_Project _value, $Res Function(_$_Project) _then)
+      : super(_value, (v) => _then(v as _$_Project));
+
+  @override
+  _$_Project get _value => super._value as _$_Project;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? name = freezed,
+    Object? workTime = freezed,
+  }) {
+    return _then(_$_Project(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      workTime: workTime == freezed
+          ? _value.workTime
+          : workTime // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_Project extends _Project {
+  _$_Project({required this.id, required this.name, required this.workTime})
+      : super._();
+
+  factory _$_Project.fromJson(Map<String, dynamic> json) =>
+      _$$_ProjectFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final String workTime;
+
+  @override
+  String toString() {
+    return 'Project(id: $id, name: $name, workTime: $workTime)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Project &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality().equals(other.workTime, workTime));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(workTime));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_ProjectCopyWith<_$_Project> get copyWith =>
+      __$$_ProjectCopyWithImpl<_$_Project>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_ProjectToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Project extends Project {
+  factory _Project(
+      {required final int id,
+      required final String name,
+      required final String workTime}) = _$_Project;
+  _Project._() : super._();
+
+  factory _Project.fromJson(Map<String, dynamic> json) = _$_Project.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get name;
+  @override
+  String get workTime;
+  @override
+  @JsonKey(ignore: true)
+  _$$_ProjectCopyWith<_$_Project> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/project.g.dart
+++ b/lib/model/project.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'project.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Project _$$_ProjectFromJson(Map<String, dynamic> json) => _$_Project(
+      id: json['id'] as int,
+      name: json['name'] as String,
+      workTime: json['workTime'] as String,
+    );
+
+Map<String, dynamic> _$$_ProjectToJson(_$_Project instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'workTime': instance.workTime,
+    };

--- a/lib/model/project_addition_state.dart
+++ b/lib/model/project_addition_state.dart
@@ -1,5 +1,4 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_study_202209/components/project_card.dart';
+import 'package:flutter_study_202209/model/project.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'project_addition_state.freezed.dart';
@@ -7,7 +6,6 @@ part 'project_addition_state.freezed.dart';
 @freezed
 class ProjectAdditionState with _$ProjectAdditionState {
   const factory ProjectAdditionState({
-    @Default([]) List<ProjectCard> projectList,
-    @Default(0) int projectCount,
+    @Default([]) List<Project> projectList,
   }) = _ProjectAdditionState;
 }

--- a/lib/model/project_addition_state.freezed.dart
+++ b/lib/model/project_addition_state.freezed.dart
@@ -16,8 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ProjectAdditionState {
-  List<ProjectCard> get projectList => throw _privateConstructorUsedError;
-  int get projectCount => throw _privateConstructorUsedError;
+  List<Project> get projectList => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $ProjectAdditionStateCopyWith<ProjectAdditionState> get copyWith =>
@@ -29,7 +28,7 @@ abstract class $ProjectAdditionStateCopyWith<$Res> {
   factory $ProjectAdditionStateCopyWith(ProjectAdditionState value,
           $Res Function(ProjectAdditionState) then) =
       _$ProjectAdditionStateCopyWithImpl<$Res>;
-  $Res call({List<ProjectCard> projectList, int projectCount});
+  $Res call({List<Project> projectList});
 }
 
 /// @nodoc
@@ -44,17 +43,12 @@ class _$ProjectAdditionStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? projectList = freezed,
-    Object? projectCount = freezed,
   }) {
     return _then(_value.copyWith(
       projectList: projectList == freezed
           ? _value.projectList
           : projectList // ignore: cast_nullable_to_non_nullable
-              as List<ProjectCard>,
-      projectCount: projectCount == freezed
-          ? _value.projectCount
-          : projectCount // ignore: cast_nullable_to_non_nullable
-              as int,
+              as List<Project>,
     ));
   }
 }
@@ -66,7 +60,7 @@ abstract class _$$_ProjectAdditionStateCopyWith<$Res>
           $Res Function(_$_ProjectAdditionState) then) =
       __$$_ProjectAdditionStateCopyWithImpl<$Res>;
   @override
-  $Res call({List<ProjectCard> projectList, int projectCount});
+  $Res call({List<Project> projectList});
 }
 
 /// @nodoc
@@ -83,17 +77,12 @@ class __$$_ProjectAdditionStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? projectList = freezed,
-    Object? projectCount = freezed,
   }) {
     return _then(_$_ProjectAdditionState(
       projectList: projectList == freezed
           ? _value._projectList
           : projectList // ignore: cast_nullable_to_non_nullable
-              as List<ProjectCard>,
-      projectCount: projectCount == freezed
-          ? _value.projectCount
-          : projectCount // ignore: cast_nullable_to_non_nullable
-              as int,
+              as List<Project>,
     ));
   }
 }
@@ -101,25 +90,20 @@ class __$$_ProjectAdditionStateCopyWithImpl<$Res>
 /// @nodoc
 
 class _$_ProjectAdditionState implements _ProjectAdditionState {
-  const _$_ProjectAdditionState(
-      {final List<ProjectCard> projectList = const [], this.projectCount = 0})
+  const _$_ProjectAdditionState({final List<Project> projectList = const []})
       : _projectList = projectList;
 
-  final List<ProjectCard> _projectList;
+  final List<Project> _projectList;
   @override
   @JsonKey()
-  List<ProjectCard> get projectList {
+  List<Project> get projectList {
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_projectList);
   }
 
   @override
-  @JsonKey()
-  final int projectCount;
-
-  @override
   String toString() {
-    return 'ProjectAdditionState(projectList: $projectList, projectCount: $projectCount)';
+    return 'ProjectAdditionState(projectList: $projectList)';
   }
 
   @override
@@ -128,16 +112,12 @@ class _$_ProjectAdditionState implements _ProjectAdditionState {
         (other.runtimeType == runtimeType &&
             other is _$_ProjectAdditionState &&
             const DeepCollectionEquality()
-                .equals(other._projectList, _projectList) &&
-            const DeepCollectionEquality()
-                .equals(other.projectCount, projectCount));
+                .equals(other._projectList, _projectList));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(_projectList),
-      const DeepCollectionEquality().hash(projectCount));
+      runtimeType, const DeepCollectionEquality().hash(_projectList));
 
   @JsonKey(ignore: true)
   @override
@@ -147,14 +127,11 @@ class _$_ProjectAdditionState implements _ProjectAdditionState {
 }
 
 abstract class _ProjectAdditionState implements ProjectAdditionState {
-  const factory _ProjectAdditionState(
-      {final List<ProjectCard> projectList,
-      final int projectCount}) = _$_ProjectAdditionState;
+  const factory _ProjectAdditionState({final List<Project> projectList}) =
+      _$_ProjectAdditionState;
 
   @override
-  List<ProjectCard> get projectList;
-  @override
-  int get projectCount;
+  List<Project> get projectList;
   @override
   @JsonKey(ignore: true)
   _$$_ProjectAdditionStateCopyWith<_$_ProjectAdditionState> get copyWith =>

--- a/lib/provider/project_addition_provider.dart
+++ b/lib/provider/project_addition_provider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_study_202209/components/project_card.dart';
+import 'package:flutter_study_202209/model/project.dart';
 import 'package:flutter_study_202209/model/project_addition_state.dart';
 
 final projectAdditionProvider =
@@ -10,20 +10,14 @@ final projectAdditionProvider =
 class ProjectAdditionProvider extends StateNotifier<ProjectAdditionState> {
   ProjectAdditionProvider() : super(const ProjectAdditionState());
 
-  incrementProjectCount() {
-    int projectCount = state.projectCount;
-    projectCount++;
-    state = state.copyWith(projectCount: projectCount);
-  }
-
-  addProject(ProjectCard project) {
+  addProject(Project project) {
     state = state.copyWith(projectList: state.projectList + [project]);
   }
 
-  removeProject(int projectCount) {
-    List<ProjectCard> projectList = [];
+  removeProject(int id) {
+    List<Project> projectList = [];
     projectList.addAll(state.projectList);
-    projectList.removeWhere((element) => element.projectCount == projectCount);
+    projectList.removeWhere((element) => element.id == id);
     state = state.copyWith(projectList: projectList);
   }
 }

--- a/lib/views/drop_down_list_view.dart
+++ b/lib/views/drop_down_list_view.dart
@@ -8,7 +8,7 @@ class DropDownListView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: Center(child: const DropDownList()),
+      body: const Center(child: DropDownList()),
     );
   }
 }

--- a/lib/views/project_add.dart
+++ b/lib/views/project_add.dart
@@ -11,23 +11,25 @@ class ProjectAddition extends ConsumerWidget {
     final projectAdditionState = ref.watch(projectAdditionProvider);
     final projectAdditionNotifier = ref.watch(projectAdditionProvider.notifier);
     return Scaffold(
-        appBar: AppBar(),
-        body: ListView.builder(
-          itemCount: projectAdditionState.projectList.length + 1,
-          itemBuilder: (context, index) {
-            if (index == projectAdditionState.projectList.length) {
-              return TextButton(
-                onPressed: () {
-                  projectAdditionNotifier.addProject(ProjectCard(
-                      projectCount: projectAdditionState.projectCount));
-                  projectAdditionNotifier.incrementProjectCount();
-                },
-                child: const Text("+プロジェクトを追加"),
-              );
-            }
-            final item = projectAdditionState.projectList[index];
-            return item;
-          },
-        ));
+      appBar: AppBar(),
+      body: ListView.builder(
+        itemCount: projectAdditionState.projectList.length + 1,
+        itemBuilder: (context, index) {
+          if (index == projectAdditionState.projectList.length) {
+            return TextButton(
+              onPressed: () {
+                projectAdditionNotifier.addProject(
+                  ProjectCard(projectCount: projectAdditionState.projectCount),
+                );
+                projectAdditionNotifier.incrementProjectCount();
+              },
+              child: const Text("+プロジェクトを追加"),
+            );
+          }
+          final item = projectAdditionState.projectList[index];
+          return item;
+        },
+      ),
+    );
   }
 }

--- a/lib/views/project_add.dart
+++ b/lib/views/project_add.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_study_202209/client/fetch_project_data.dart';
 import 'package:flutter_study_202209/components/project_card.dart';
+import 'package:flutter_study_202209/model/project.dart';
 import 'package:flutter_study_202209/provider/project_addition_provider.dart';
 
 class ProjectAddition extends ConsumerWidget {
@@ -10,6 +12,7 @@ class ProjectAddition extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final projectAdditionState = ref.watch(projectAdditionProvider);
     final projectAdditionNotifier = ref.watch(projectAdditionProvider.notifier);
+    Project newProject;
     return Scaffold(
       appBar: AppBar(),
       body: ListView.builder(
@@ -18,16 +21,14 @@ class ProjectAddition extends ConsumerWidget {
           if (index == projectAdditionState.projectList.length) {
             return TextButton(
               onPressed: () {
-                projectAdditionNotifier.addProject(
-                  ProjectCard(projectCount: projectAdditionState.projectCount),
-                );
-                projectAdditionNotifier.incrementProjectCount();
+                newProject = FetchData.fetchProject();
+                projectAdditionNotifier.addProject(newProject);
               },
               child: const Text("+プロジェクトを追加"),
             );
           }
-          final item = projectAdditionState.projectList[index];
-          return item;
+          final project = projectAdditionState.projectList[index];
+          return ProjectCard(project: project);
         },
       ),
     );

--- a/lib/views/project_add.dart
+++ b/lib/views/project_add.dart
@@ -13,6 +13,7 @@ class ProjectAddition extends ConsumerWidget {
     final projectAdditionState = ref.watch(projectAdditionProvider);
     final projectAdditionNotifier = ref.watch(projectAdditionProvider.notifier);
     Project newProject;
+    List<String> projectNames = [];
     return Scaffold(
       appBar: AppBar(),
       body: ListView.builder(
@@ -22,13 +23,17 @@ class ProjectAddition extends ConsumerWidget {
             return TextButton(
               onPressed: () {
                 newProject = FetchData.fetchProject();
+                projectNames = FetchData.fetchProjectNames();
                 projectAdditionNotifier.addProject(newProject);
               },
               child: const Text("+プロジェクトを追加"),
             );
           }
           final project = projectAdditionState.projectList[index];
-          return ProjectCard(project: project);
+          return ProjectCard(
+            project: project,
+            projectNames: projectNames,
+          );
         },
       ),
     );


### PR DESCRIPTION
## 行ったこと
- `ConsumerWidget`型のWidget`ProjectCard`をListにしてProviderで管理していたものを、id, name, workTimeのデータを持つclass`Project`のデータを管理し、そのデータを元にProjectCardを作るやり方に変更。
- idは1,2桁の数字をランダムで返す関数から取得してくる方法をとった。

## 動作確認

https://user-images.githubusercontent.com/82959924/189334262-07e48c5c-bcf4-49cf-81e0-739ca4bddad8.mp4



## その他
- ドロップダウンでプロジェクト名を選択するとproviderで管理しているnameが変更されるようにしたかったのですが、ConsumerWidgetにするとSetStateが使えず、ドロップダウン画面で名前が変更されず、詰まってしまったため未実装です。